### PR TITLE
chore: Update EC2 instance IP in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: SSH to EC2 and Deploy
         run: |
-          ssh ubuntu@ec2-13-60-35-142.eu-north-1.compute.amazonaws.com << EOF
+          ssh ubuntu@ec2-16-171-23-80.eu-north-1.compute.amazonaws.com << EOF
             cd fastapi-book-project
             if [ ! -d "venv" ]; then
                 python3 -m venv venv


### PR DESCRIPTION
## Description  
- Enhance GitHub Actions deployment workflow for FastAPI project


## Related Task  
[HNG12 Stage 2 Task]

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbot` as a collaborator.  
- Deployment URL: `http://16.171.23.80`