### PR TITLE
chore: Improve SSH connection in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,13 @@ jobs:
           key: ${{ secrets.FASTAPI_PEM_KEY }}
           known_hosts: 'just accept'
 
+      - name: Add Host to Known Hosts
+        run: |
+          ssh-keyscan -H ec2-16-171-23-80.eu-north-1.compute.amazonaws.com >> ~/.ssh/known_hosts
+
       - name: SSH to EC2 and Deploy
         run: |
-          ssh ubuntu@ec2-16-171-23-80.eu-north-1.compute.amazonaws.com << EOF
+          ssh -t ubuntu@ec2-16-171-23-80.eu-north-1.compute.amazonaws.com << EOF
             cd fastapi-book-project
             if [ ! -d "venv" ]; then
                 python3 -m venv venv


### PR DESCRIPTION
## Description  
- Improve GitHub Actions deployment workflow for FastAPI project

## Related Task  
[HNG12 Stage 2 Task](#task-description-link)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbot` as a collaborator.  
- Deployment URL: `http://16.171.23.80`