### PR TITLE
chore: Ensure clean port 8000 before starting Gunicorn server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,5 +32,6 @@ jobs:
             fi
             source venv/bin/activate
             pip install -r requirements.txt
+            fuser -k 8000/tcp || true
             gunicorn main:app --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class uvicorn.workers.UvicornWorker
           EOF


### PR DESCRIPTION
## Description  
- Ensure clean port 8000 before starting Gunicorn server

## Related Task  
[HNG12 Stage 2 Task]

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbot` as a collaborator.  
- Deployment URL: `http://16.171.23.80`