### PR TITLE
chore: Run Gunicorn server in background with nohup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,5 +34,6 @@ jobs:
             source venv/bin/activate
             pip install -r requirements.txt
             fuser -k 8000/tcp || true
-            gunicorn main:app --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class uvicorn.workers.UvicornWorker
+            nohup gunicorn main:app --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class uvicorn.workers.UvicornWorker &
+            exit
           EOF


### PR DESCRIPTION
## Description  
- Run Gunicorn server in background with nohup

## Related Task  
[HNG12 Stage 2 Task]

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-devbot` as a collaborator.  
- Deployment URL: `http://16.171.23.80`