### PR TITLE
chore: Redirect Gunicorn server logs to file for better debugging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,6 +34,6 @@ jobs:
             source venv/bin/activate
             pip install -r requirements.txt
             fuser -k 8000/tcp || true
-            nohup gunicorn main:app --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class uvicorn.workers.UvicornWorker &
+            nohup gunicorn main:app --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class uvicorn.workers.UvicornWorker > gunicorn.log 2>&1 &
             exit
           EOF


### PR DESCRIPTION
## Description  
- Redirect Gunicorn server logs to file for better debugging

## Related Task  
[HNG12 Stage 2 Task](#task-description-link)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited `hng12-dev` as a collaborator.  
- Deployment URL: `http://16.171.23.80`